### PR TITLE
Fix: Set search_path for handle_new_user function

### DIFF
--- a/supabase/migrations/20250708054457-da99167e-abff-401e-8225-d483da937001.sql
+++ b/supabase/migrations/20250708054457-da99167e-abff-401e-8225-d483da937001.sql
@@ -41,6 +41,7 @@ WITH CHECK (auth.uid() = id);
 CREATE OR REPLACE FUNCTION public.handle_new_user()
 RETURNS TRIGGER AS $$
 BEGIN
+  SET search_path = public;
   INSERT INTO public.profiles (id, username, display_name, avatar_url)
   VALUES (
     NEW.id,


### PR DESCRIPTION
Addresses a security warning regarding mutable function search_paths by explicitly setting it to 'public' for the handle_new_user function.

Advised user on dashboard configurations for Leaked Password Protection and MFA options as these are not code-based changes.